### PR TITLE
feat: 问题提交格式

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,5 +47,6 @@ App({
   },
   onLaunch: function () {
     console.log('当前服务地址::', this.getDomain())
+    console.log('问题提交格式');
   }
 })


### PR DESCRIPTION
初级：
- 问题1： map 组件的 callout 属性不生效；
  - 产生原因：在使用官方示例的 map 组件时，发现 callout 属性不生效；
  - 解决方法：[查阅文档](https://microapp.bytedance.com/docs/zh-CN/mini-app/develop/component/map/map/#marker)发现，该属性需要基础库版本 2.15.0，需要抖音 16.8.0 版本以上