### PR TITLE
feat: 中级+高级

### DIFF
--- a/pages/normal/question1/index.js
+++ b/pages/normal/question1/index.js
@@ -12,10 +12,16 @@ Page({
         },
         fail: (err) => {
           console.error("请求失败：", err);
-          tt.showModal({
-            title: "网络错误",
-            content: JSON.stringify(err),
-          });
+          /**
+           * 
+           * 可在onShow时增加判断取消弹窗。
+           * 在后台失败时，弹窗也不能被用户看到，也可取消弹窗提示。
+           * 如果这个请求比较重要，可记录请求失败的状态，在onShow时重新尝试发送
+           */
+          // tt.showModal({
+          //   title: "网络错误",
+          //   content: JSON.stringify(err),
+          // });
         }
       });
     }, 8000)

--- a/pages/normal/question2/index.js
+++ b/pages/normal/question2/index.js
@@ -82,7 +82,10 @@ Page({
   sendMessageAB: function () {
     let that = this;
     if (this.socket) {
-      let ab = new Uint8Array(10);
+      /**
+       * 发送的是ArraryBuffer
+       */
+      let ab = (new Uint8Array(10)).buffer;
       this.socket.send({
         data: ab,
         success() {

--- a/pages/normal/question3/index.js
+++ b/pages/normal/question3/index.js
@@ -27,8 +27,11 @@ Page({
           method: "POST",
           data: {
             access_token: this.data.access_token,
-            appid: "ttba89cc3425b1d98b01",
-            tplid: "MSG123251735bc0f19005a318abdce9ad79e8b982113929",
+            /**
+             * 参数名写错了
+             */
+            app_id: "ttba89cc3425b1d98b01",
+            tpl_id: "MSG123251735bc0f19005a318abdce9ad79e8b982113929",
             open_id: this.data.openid,
             data: {
               "查询内容": "示例",

--- a/pages/normal/question4/index.js
+++ b/pages/normal/question4/index.js
@@ -10,9 +10,12 @@ Page({
     console.log("相关问题：https://forum.microapp.bytedance.com/mini-app/posts/608537f91e04b37e5eaf9dc4")
   },
   onShow() {
-    tt.login({
-      success: res => console.log("==onShow== success：", res),
-      fail: err => console.log("==onShow== fail：", err)
-    });
+    /**
+     * 没必要连续调用
+     */
+    // tt.login({
+    //   success: res => console.log("==onShow== success：", res),
+    //   fail: err => console.log("==onShow== fail：", err)
+    // });
   }
 })

--- a/pay-server/server/pay.json
+++ b/pay-server/server/pay.json
@@ -1,1 +1,1 @@
-{"appid":"tt07e3715e98c9aac0","salt":"la9ldrZRTI1C4tphK0JHYsTMtX6bBQPSnwylIPbF","port":8001,"domain":"10.79.9.133"}
+{"appid":"tt07e3715e98c9aac0","salt":"la9ldrZRTI1C4tphK0JHYsTMtX6bBQPSnwylIPbF","port":8001,"domain":"172.30.105.113"}

--- a/pay-server/server/src/pay.js
+++ b/pay-server/server/src/pay.js
@@ -21,7 +21,8 @@ var pay_json_1 = __importDefault(require("../pay.json"));
 var createOrderUrl = 'https://developer.toutiao.com/api/apps/ecpay/v1/create_order';
 var repayOrderUrl = 'https://developer.toutiao.com/api/apps/ecpay/v1/create_refund';
 var SALT = pay_json_1["default"].salt;
-var exclude = ['sign', 'appid', 'thirdparty_id'];
+// 字段名写错了
+var exclude = ['sign', 'app_id', 'thirdparty_id'];
 var app_id = pay_json_1["default"].appid;
 function md5(str) {
     var _md5 = crypto_1["default"].createHash('md5');

--- a/pay-server/src/pay.ts
+++ b/pay-server/src/pay.ts
@@ -6,7 +6,8 @@ const createOrderUrl = 'https://developer.toutiao.com/api/apps/ecpay/v1/create_o
 const repayOrderUrl = 'https://developer.toutiao.com/api/apps/ecpay/v1/create_refund';
 
 const SALT = payConf.salt;
-const exclude = ['sign', 'appid', 'thirdparty_id'];
+// 字段名写错了
+const exclude = ['sign', 'app_id', 'thirdparty_id'];
 const app_id = payConf.appid;
 
 function md5(str: string) {


### PR DESCRIPTION

### 中级
题目一：
问题描述： 在小程序切入后台（注：是点击小程序右上角【×】切入后台，而不是APP切入后台）后调用 tt.request 会触发报错 【request: fail app in background】
问题原因： 小程序弹框报错的原因：页面onHide时发送了网络请求，并在请求失败时调用了弹窗来提示请求失败。重新进入页面时弹窗并没有被关闭，所以重新进入时能看到弹窗报错。
解决方案： 在页面onShow、onHide时增加判断标识，进入前台时关闭弹窗（在后台的弹窗不能被看到，也可选择console等处理方式）。如果该网络请求比较重要，可尝试重新发送（但目前来看是小程序系统问题，发送还会失败）；或者失败后在storage中做个标识，等onShow的时候重新发送。

题目二：
问题描述： 使用 websocket 发送二进制数据在 IDE 正常，但是真机调试，服务端收到的是 String 类型的数据，请使用真机调试
问题原因： websocket发送数据时，仅支持发送string和arraybuffer类型，示例中发送的是使用Uint8Array创建的无符号整型数组。arraybuffer表示一段可连续存储数据的内存。
解决方案： 使用Uint8Array创建的实例对象的arraybuffer存在这个对象的buffer属性中，获取后，作为参数发送。

题目三：
问题描述： 已授权订阅消息成功，但是后台请求接口返回【该用户未订阅】
问题原因： 服务端发送请求时参数名不对
解决方案： 将参数名修改正确，appid修改为app_id，tplid改为tpl_id

题目四：
问题描述： 连续调用 tt.login 在 iOS 上报错 【login:fail login is in progress, please do not call again】，请使用iOS真机调试
问题原因： tt.login短时间内重复调用
解决方案： 避免短时间内重复调用。如一定需要获取，可尝试失败后重试。


### 高级
题目一：
问题描述： 服务端支付签名一直报签名错误，请根据提供的密钥和订单参数JSON生成正确的签名(sign)
问题原因： 生成签名时需要排除"thirdparty_id", "app_id", "sign"，其中app_id写成了appid，导致签名出错。
解决方案： 把appid改成app_id

题目二：
问题描述： 1、担保交易有一笔订单，分两部分退款，结果只收到一笔订单的退款，但是接口提示退单成功；2、调用服务端退款接口，一直处于退款中
测试结果： 把题目一中支付的订单，在这个题目中分两部分退掉，可以收到退款，没有发现问题。

![image](https://user-images.githubusercontent.com/6994858/133016864-fbdd3f4d-bb9b-47a2-811d-523309844f6b.png)




